### PR TITLE
SOCINT-169 added docker compose config to fix eq error

### DIFF
--- a/docker/docker-compose-rh-service.yml
+++ b/docker/docker-compose-rh-service.yml
@@ -26,3 +26,4 @@ services:
     - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
     - spring.profiles.active=local
     - spring.cloud.gcp.pubsub.emulator-host=host.docker.internal:9808
+    - rate-limiter.rest-client-config.host=host.docker.internal


### PR DESCRIPTION
# Motivation and Context
rh-svc docker compose was missing configuration for the rate limiter, causing a connection error in the logs

# What has changed
added config as shown in the ticket

# How to test?
Follow steps in ticket and confirm no error in rhsvc logs

# Links
https://collaborate2.ons.gov.uk/jira/browse/SOCINT-169
