### PR TITLE
SOCINT-215 Directly logging non-sensitive fields only for new case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/endpoint/CaseEndpoint.java
@@ -119,7 +119,17 @@ public class CaseEndpoint {
   @ResponseStatus(value = HttpStatus.OK)
   public void newCase(@Valid @RequestBody NewCaseDTO caseRegistrationDTO) throws CTPException {
     String methodName = "newCaseRegistration";
-    log.info("Entering POST {}", methodName, kv("requestBody", caseRegistrationDTO));
+
+    // Only log non-sensitive fields, as current kv logging doesn't support data fields
+    log.info(
+        "Entering POST {}",
+        methodName,
+        kv("surveyId", caseRegistrationDTO.getSurveyId()),
+        kv("collectionExerciseId", caseRegistrationDTO.getCollectionExerciseId()),
+        kv("schoolId", caseRegistrationDTO.getSchoolId()),
+        kv("schoolName", caseRegistrationDTO.getSchoolName()),
+        kv("consentGivenTest", caseRegistrationDTO.isConsentGivenTest()),
+        kv("consentGivenSurvey", caseRegistrationDTO.isConsentGivenSurvey()));
 
     // Reject if consent not given
     verifyIsTrue(caseRegistrationDTO.isConsentGivenTest(), "consentGivenTest");


### PR DESCRIPTION
This change prevents the leaking of the child's date of birth by logging only the non sensitive fields of the new case object.