### PR TITLE
Socint 256 correct uac authentication pubsub naming

### DIFF
--- a/docs/MANUAL_TESTING.md
+++ b/docs/MANUAL_TESTING.md
@@ -36,16 +36,16 @@ You should see an acknowledgement in the RHSvc logs, and the message should now 
 
 Ensure that you have successfully received a `CASE_UPDATE` and matching `UAC_UPDATE` event from the above steps, and that both appear in firestore
 
-Create a subscription for the `event_uac-authenticate` topic using
+Create a subscription for the `event_uac-authentication` topic using
 
-    `python subscriber.py local create event_uac-authenticate fake_subscription`
+    `python subscriber.py local create event_uac-authentication fake_subscription`
 
 In a new terminal window run:
 
     $(gcloud beta emulators pubsub env-init)
     python3 subscriber.py local receive fake_subscription
 
-Generate respondent authenticated event using the `uacHash` from the previously sent `UAC_UPDATE` event and hitting the `uacs` endpoint
+Generate respondent authentication event using the `uacHash` from the previously sent `UAC_UPDATE` event and hitting the `uacs` endpoint
 
        $ curl -s -H "Content-Type: application/json" "http://localhost:8071/uacs/<UAC_HASH>"
 
@@ -66,7 +66,7 @@ Format the event text and make sure it looks like:
 
 	{
 	  "event": {
-	    "type": "RESPONDENT_AUTHENTICATED",
+	    "type": "RESPONDENT_AUTHENTICATION",
 	    "source": "RESPONDENT_HOME",
 	    "channel": "RH",
 	    "dateTime": "2019-06-24T10:38:07.550Z",

--- a/docs/PUBSUB.md
+++ b/docs/PUBSUB.md
@@ -34,7 +34,7 @@ Create the following topics/subscriptions:
       event_uac-update                 | event_uac-update_rh
       event_survey-update              | event_survey-update_rh
       event_collection-exercise-update | event_collection-exercise-update_rh
-      event_uac-authenticate           | N/A
+      event_uac-authentication         | N/A
       event_survey-launch              | N/A
       event_fulfilment                 | N/A
       event_new-case                   | N/A
@@ -43,7 +43,7 @@ Create the following topics/subscriptions:
     python publisher.py local create event_uac-update
     python publisher.py local create event_survey-update
     python publisher.py local create event_collection-exercise-update
-    python publisher.py local create event_uac-authenticate
+    python publisher.py local create event_uac-authentication
     python publisher.py local create event_survey-launch
     python publisher.py local create event_fulfilment
     python publisher.py local create event_new-case

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
     <!-- change this to the version of ALL common libs to be used by this build -->
-    <version>1.0.51</version>
+    <version>1.0.52-256-SNAPSHOT</version>
   </parent>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
     <!-- change this to the version of ALL common libs to be used by this build -->
-    <version>1.0.52-256-SNAPSHOT</version>
+    <version>1.0.56</version>
   </parent>
 
   <scm>

--- a/scripts/pubsub-setup.sh
+++ b/scripts/pubsub-setup.sh
@@ -37,7 +37,7 @@ bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' '$PUBSUB_HOST:$PUB
 echo "<<< Creating topics >>>"
 createTopic event_case-update
 createTopic event_uac-update
-createTopic event_uac-authenticate
+createTopic event_uac-authentication
 createTopic event_survey-launch
 createTopic event_fulfilment
 createTopic event_survey-update

--- a/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImpl.java
@@ -15,7 +15,7 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.TopicType;
 import uk.gov.ons.ctp.common.event.model.CaseUpdate;
-import uk.gov.ons.ctp.common.event.model.UacAuthenticateResponse;
+import uk.gov.ons.ctp.common.event.model.UacAuthenticationResponse;
 import uk.gov.ons.ctp.common.event.model.UacUpdate;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
 import uk.gov.ons.ctp.integration.rhsvc.representation.UniqueAccessCodeDTO;
@@ -62,7 +62,7 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
         log.debug("UAC is unlinked", kv("uacHash", uacHash));
         data = createUniqueAccessCodeDTO(uacMatch.get(), Optional.empty(), CaseStatus.UNLINKED);
       }
-      sendUacAuthenticatedEvent(data);
+      sendUacAuthenticationEvent(data);
     } else {
       log.warn("Unknown UAC", kv("uacHash", uacHash));
       throw new CTPException(CTPException.Fault.RESOURCE_NOT_FOUND, "Failed to retrieve UAC");
@@ -71,26 +71,26 @@ public class UniqueAccessCodeServiceImpl implements UniqueAccessCodeService {
     return data;
   }
 
-  /** Send UacAuthenticated event */
-  private void sendUacAuthenticatedEvent(UniqueAccessCodeDTO data) throws CTPException {
+  /** Send UacAuthentication event */
+  private void sendUacAuthenticationEvent(UniqueAccessCodeDTO data) throws CTPException {
 
     log.info(
-        "Generating UacAuthenticated event for caseId",
+        "Generating UacAuthentication event for caseId",
         kv("caseId", data.getCaseId()),
         kv("questionnaireId", data.getQid()));
 
-    UacAuthenticateResponse response =
-        UacAuthenticateResponse.builder()
+    UacAuthenticationResponse response =
+        UacAuthenticationResponse.builder()
             .questionnaireId(data.getQid())
             .caseId(data.getCaseId())
             .build();
 
     UUID messageId =
         eventPublisher.sendEvent(
-            TopicType.UAC_AUTHENTICATE, Source.RESPONDENT_HOME, Channel.RH, response);
+            TopicType.UAC_AUTHENTICATION, Source.RESPONDENT_HOME, Channel.RH, response);
 
     log.debug(
-        "UacAuthenticated event published for caseId: "
+        "UacAuthentication event published for caseId: "
             + response.getCaseId()
             + ", messageId: "
             + messageId);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhsvc/service/impl/UniqueAccessCodeServiceImplTest.java
@@ -27,7 +27,7 @@ import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.TopicType;
 import uk.gov.ons.ctp.common.event.model.CaseUpdate;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
-import uk.gov.ons.ctp.common.event.model.UacAuthenticateResponse;
+import uk.gov.ons.ctp.common.event.model.UacAuthenticationResponse;
 import uk.gov.ons.ctp.common.event.model.UacUpdate;
 import uk.gov.ons.ctp.integration.rhsvc.RHSvcBeanMapper;
 import uk.gov.ons.ctp.integration.rhsvc.repository.RespondentDataRepository;
@@ -53,8 +53,8 @@ public class UniqueAccessCodeServiceImplTest {
   @Test
   public void getUACLinkedToExistingCase() throws Exception {
 
-    ArgumentCaptor<UacAuthenticateResponse> payloadCapture =
-        ArgumentCaptor.forClass(UacAuthenticateResponse.class);
+    ArgumentCaptor<UacAuthenticationResponse> payloadCapture =
+        ArgumentCaptor.forClass(UacAuthenticationResponse.class);
 
     UacUpdate uacTest = getUAC("linkedHousehold");
     CaseUpdate caseTest = getCase("household");
@@ -68,7 +68,7 @@ public class UniqueAccessCodeServiceImplTest {
     verify(dataRepo, times(1)).readCaseUpdate(CASE_ID);
     verify(eventPublisher, times(1))
         .sendEvent(
-            eq(TopicType.UAC_AUTHENTICATE),
+            eq(TopicType.UAC_AUTHENTICATION),
             eq(Source.RESPONDENT_HOME),
             eq(Channel.RH),
             payloadCapture.capture());
@@ -94,7 +94,7 @@ public class UniqueAccessCodeServiceImplTest {
     assertEquals(uacTest.isEqLaunched(), uacDTO.isEqLaunched());
     assertEquals(uacTest.getMetadata().getWave(), uacDTO.getWave());
 
-    UacAuthenticateResponse payload = payloadCapture.getValue();
+    UacAuthenticationResponse payload = payloadCapture.getValue();
     assertEquals(uacDTO.getCaseId(), payload.getCaseId());
     assertEquals(uacDTO.getQid(), payload.getQuestionnaireId());
   }
@@ -102,8 +102,8 @@ public class UniqueAccessCodeServiceImplTest {
   @Test
   public void getUACLinkedToCaseThatCannotBeFound() throws Exception {
 
-    ArgumentCaptor<UacAuthenticateResponse> payloadCapture =
-        ArgumentCaptor.forClass(UacAuthenticateResponse.class);
+    ArgumentCaptor<UacAuthenticationResponse> payloadCapture =
+        ArgumentCaptor.forClass(UacAuthenticationResponse.class);
 
     UacUpdate uacTest = getUAC("linkedHousehold");
 
@@ -116,7 +116,7 @@ public class UniqueAccessCodeServiceImplTest {
 
     verify(eventPublisher, times(1))
         .sendEvent(
-            eq(TopicType.UAC_AUTHENTICATE),
+            eq(TopicType.UAC_AUTHENTICATION),
             eq(Source.RESPONDENT_HOME),
             eq(Channel.RH),
             payloadCapture.capture());
@@ -131,7 +131,7 @@ public class UniqueAccessCodeServiceImplTest {
 
     assertNull(uacDTO.getAddress());
 
-    UacAuthenticateResponse payload = payloadCapture.getValue();
+    UacAuthenticationResponse payload = payloadCapture.getValue();
     assertNull(payload.getCaseId());
     assertEquals(uacDTO.getQid(), payload.getQuestionnaireId());
 
@@ -143,8 +143,8 @@ public class UniqueAccessCodeServiceImplTest {
   @Test
   public void getUACNotLInkedToCase() throws Exception {
 
-    ArgumentCaptor<UacAuthenticateResponse> payloadCapture =
-        ArgumentCaptor.forClass(UacAuthenticateResponse.class);
+    ArgumentCaptor<UacAuthenticationResponse> payloadCapture =
+        ArgumentCaptor.forClass(UacAuthenticationResponse.class);
 
     UacUpdate uacTest = getUAC("unlinkedHousehold");
 
@@ -156,7 +156,7 @@ public class UniqueAccessCodeServiceImplTest {
     verify(dataRepo, times(0)).readCaseUpdate(CASE_ID);
     verify(eventPublisher, times(1))
         .sendEvent(
-            eq(TopicType.UAC_AUTHENTICATE),
+            eq(TopicType.UAC_AUTHENTICATION),
             eq(Source.RESPONDENT_HOME),
             eq(Channel.RH),
             payloadCapture.capture());
@@ -171,7 +171,7 @@ public class UniqueAccessCodeServiceImplTest {
 
     assertNull(uacDTO.getAddress());
 
-    UacAuthenticateResponse payload = payloadCapture.getValue();
+    UacAuthenticationResponse payload = payloadCapture.getValue();
     assertEquals(uacDTO.getCaseId(), payload.getCaseId());
     assertEquals(uacDTO.getQid(), payload.getQuestionnaireId());
 


### PR DESCRIPTION
Knock-on changes caused by renaming the 'authenticate' topic+subscription to 'authentication'.